### PR TITLE
Fix the ROUGE_path in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The only things you need to evaluate ROUGE score is to specify the paths of ROUG
 ```
 from pythonrouge.pythonrouge import Pythonrouge
 
-ROUGE = sys.argv[1] #ROUGE-1.5.5.pl
+ROUGE_path = sys.argv[1] #ROUGE-1.5.5.pl
 data_path = sys.argv[2] #data folder in RELEASE-1.5.5
 
 # initialize setting of ROUGE, eval ROUGE-1, 2, SU4, L

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ After putting system/reference files as above, you can evaluate ROUGE metrics as
 ```
 from pythonrouge.pythonrouge import Pythonrouge
 
-ROUGE = sys.argv[1] #ROUGE-1.5.5.pl
+ROUGE_path = sys.argv[1] #ROUGE-1.5.5.pl
 data_path = sys.argv[2] #data folder in RELEASE-1.5.5
 
 # initialize setting of ROUGE, eval ROUGE-1~4, SU4


### PR DESCRIPTION
The `ROUGE` in the README should be  `ROUGE_path`